### PR TITLE
Use protocol relative link in comment embed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ if ( post_password_required() )
 
 <a id="nodebb/comments"></a>
 <script type="text/javascript">
-var nodeBBURL = 'http://your.nodebb.com',
+var nodeBBURL = '//your.nodebb.com',
 	articleID = '<?php echo the_ID(); ?>';
 
 (function() {


### PR DESCRIPTION
In order to avoid mixed content warnings/blocks when the blog is served via `https` but the `nodeBBURL` is using `http` use protocol relative links.

This enables hosts who want to serve over secure connections do so without breaking functionality for users who visit over the unsecure one (say, if SSL was enabled some time after the initial launch of the blog and `http` traffic isn't redirected to `https` automatically).
