### PR TITLE
Gravatar default image with HTTPS

### DIFF
--- a/public/templates/comments/comments.tpl
+++ b/public/templates/comments/comments.tpl
@@ -4,7 +4,7 @@
 			<!-- IF isLoggedIn -->
 			<img src="{user.picture}" class="profile-image" />
 			<!-- ELSE -->
-			<img src="http://1.gravatar.com/avatar/177d180983be7a2c95a4dbe7451abeba?s=95&d=&r=PG" class="profile-image" />
+			<img src="https://1.gravatar.com/avatar/177d180983be7a2c95a4dbe7451abeba?s=95&d=&r=PG" class="profile-image" />
 			<!-- ENDIF isLoggedIn -->
 		</div>
 		<form action="{relative_path}/comments/reply" method="post">


### PR DESCRIPTION
The Gravatar link should be HTTPS because:
 - HTTPS is recommended by Google: http://googlewebmastercentral.blogspot.fr/2014/08/https-as-ranking-signal.html
- If the Gravatar link is in HTTP, it creates mixed content, because your Ghost/WP blog is often HTTPS for SEO, so, it's not good.