### PR TITLE
Force cid from blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Paste this any where in `yourtheme/post.hbs`, somewhere between `{{#post}}` and 
 <script type="text/javascript">
 var nbb = {};
 nbb.url = '//your.nodebb.com'; // EDIT THIS
+nbb.cid = 1;	// OPTIONAL. Forces a Category ID in NodeBB.
+				//  Omit it to fallback to specified IDs in the admin panel.
 
 (function() {
 nbb.articleID = '{{../post.id}}'; nbb.title = '{{../post.title}}';
@@ -64,7 +66,9 @@ if ( post_password_required() )
 <a id="nodebb/comments"></a>
 <script type="text/javascript">
 var nodeBBURL = '//your.nodebb.com',
-	articleID = '<?php echo the_ID(); ?>';
+	articleID = '<?php echo the_ID(); ?>',
+	categoryID = 1; // OPTIONAL. Forces a Category ID in NodeBB.
+					 //  Omit it to fallback to specified IDs in the admin panel.
 
 (function() {
 var nbb = document.createElement('script'); nbb.type = 'text/javascript'; nbb.async = true;
@@ -75,8 +79,8 @@ nbb.src = nodeBBURL + '/plugins/nodebb-plugin-blog-comments/lib/wordpress.js';
 <noscript>Please enable JavaScript to view comments</noscript>
 ```
 
-### General PHP
-Paste this any where that you want load commenting system. All you have to edit is line 3 (`nodeBBURL`) - put the URL to your NodeBB forum's home page here.
+### General - PHP example
+Paste this any where that you want load commenting system. All you have to edit is line 3 (`nodeBBURL`) - put the URL to your NodeBB forum's home page here. You can also use any template engine (hbs, eco...) instead of PHP.
 
 ```html
 	<a id="nodebb/comments"></a>
@@ -90,6 +94,8 @@ Paste this any where that you want load commenting system. All you have to edit 
 		$obj->url="";
 		$obj->tags = [];
 		$obj->markDownContent= "";
+		$obj->cid = 1; // OPTIONAL. Forces a Category ID in NodeBB.
+						// Omit it to fallback to specified IDs in the admin panel.
 		echo "var articleData =" .json_encode($obj).";";
 	?>
 	

--- a/library.js
+++ b/library.js
@@ -131,24 +131,27 @@
 			url = req.body.url,
 			commentID = req.body.id,
 			tags = req.body.tags,
-			uid = req.user ? req.user.uid : 0;
+			uid = req.user ? req.user.uid : 0,
+			cid = JSON.parse(req.body.cid);
 
-		var hostUrls = (meta.config['blog-comments:url'] || '').split(','),
-			position = 0;
+		if (cid === -1) {
+			var hostUrls = (meta.config['blog-comments:url'] || '').split(','),
+				position = 0;
 
-		hostUrls.forEach(function(hostUrl, i) {
-			hostUrl = hostUrl.trim();
-			if (hostUrl[hostUrl.length - 1] === '/') {
-				hostUrl = hostUrl.substring(0, hostUrl.length - 1);
-			}
+			hostUrls.forEach(function(hostUrl, i) {
+				hostUrl = hostUrl.trim();
+				if (hostUrl[hostUrl.length - 1] === '/') {
+					hostUrl = hostUrl.substring(0, hostUrl.length - 1);
+				}
 
-			if (hostUrl === req.get('origin')) {
-				position = i;
-			}
-		});
+				if (hostUrl === req.get('origin')) {
+					position = i;
+				}
+			});
 
-		var cid = meta.config['blog-comments:cid'].toString() || '';
-		cid = parseInt(cid.split(',')[position], 10) || parseInt(cid.split(',')[0], 10) || 1;
+			cid = meta.config['blog-comments:cid'].toString() || '';
+			cid = parseInt(cid.split(',')[position], 10) || parseInt(cid.split(',')[0], 10) || 1;
+		}
 
 		async.parallel({
 			isAdministrator: function(next) {

--- a/public/lib/general.js
+++ b/public/lib/general.js
@@ -151,6 +151,7 @@
 								gTags = articleData.tags,
 								url = articleData.url,
 								title= articleData.title_plain,
+								cid = articleData.cid || -1,
 								tags = [];
 							translator.innerHTML = articleData.markDownContent;
 
@@ -163,6 +164,7 @@
 							}
 							document.getElementById('nodebb-content-markdown').value = markdown;
 							document.getElementById('nodebb-content-title').value = title;
+							document.getElementById('nodebb-content-cid').value = cid;
 							document.getElementById('nodebb-content-tags').value = JSON.stringify(tags);
 						} else {
 							console.error('Declare articleData variable!');

--- a/public/lib/ghost.js
+++ b/public/lib/ghost.js
@@ -150,6 +150,7 @@
 
 					document.getElementById('nodebb-content-title').value = nbb.title;
 					document.getElementById('nodebb-content-markdown').value = markdown;
+					document.getElementById('nodebb-content-cid').value = nbb.cid || -1;
 					document.getElementById('nodebb-content-tags').value = JSON.stringify(nbb.tags);
 				}
 			}

--- a/public/lib/wordpress.js
+++ b/public/lib/wordpress.js
@@ -167,6 +167,7 @@
 
 							document.getElementById('nodebb-content-markdown').value = markdown;
 							document.getElementById('nodebb-content-title').value = articleData.title_plain;
+							document.getElementById('nodebb-content-cid').value = categoryID || -1;
 							document.getElementById('nodebb-content-tags').value = JSON.stringify(tags);
 						} else {
 							console.warn('Unable to access API. Please install the JSON API plugin located at: http://wordpress.org/plugins/json-api');

--- a/public/templates/comments/comments.tpl
+++ b/public/templates/comments/comments.tpl
@@ -82,6 +82,7 @@
 		<button class="btn btn-primary">Publish this article to NodeBB</button>
 		<input type="hidden" name="markdown" id="nodebb-content-markdown" />
 		<input type="hidden" name="title" id="nodebb-content-title" />
+		<input type="hidden" name="cid" id="nodebb-content-cid" />
 		<input type="hidden" name="tags" id="nodebb-content-tags" />
 		<input type="hidden" name="id" value="{article_id}" />
 		<input type="hidden" name="url" value="{redirect_url}" />


### PR DESCRIPTION
@psychobunny Right now it's possible to map different blog domains to different categories in the same NodeBB, but if your blogs are all under the same domain (different sub-directories) I think it's not possible. For example, I have a blog in `domain.com/blog` and another one in `domain.com/reference`. The plugin checks`req.get('origin')` and it does not contain the paths.

I'm just adding here a new `cid` field to the request. If it's undefined it fallbacks to the default behavior.