### PR TITLE
Reply/Quote comments

### DIFF
--- a/library.js
+++ b/library.js
@@ -110,11 +110,13 @@
 		var content = req.body.content,
 			tid = req.body.tid,
 			url = req.body.url,
+			toPid = req.body.toPid,
 			uid = req.user ? req.user.uid : 0;
 
 		topics.reply({
 			tid: tid,
 			uid: uid,
+			toPid: toPid,
 			content: content
 		}, function(err, postData) {
 			if(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-blog-comments",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "NodeBB Blog Comments (Ghost / WP Commenting Engine)",
   "main": "library.js",
   "scripts": {

--- a/public/css/comments.css
+++ b/public/css/comments.css
@@ -58,6 +58,7 @@
 	color: #333;
 	overflow: hidden;
 	word-wrap: break-word;
+	transition: background-color 0.6s ease;
 }
 
 #nodebb .topic-text blockquote {
@@ -89,7 +90,7 @@
 
 #nodebb > ul {
     margin-bottom: 0px;
-    margin-top: 20px;
+    margin-top: 25px;
     list-style-type: none;
     padding: 0px;
 }
@@ -205,4 +206,63 @@
 	width: 20px;
 	height: 20px;
 	border-radius: 100%;
+}
+
+.sub-reply-input {
+	margin-left: 20px;
+	margin-right: 20px;
+	margin-bottom: 10px;
+	padding-bottom: 48px;
+}
+
+.no-select {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+}
+
+.post-tools {
+	float: right;
+	text-transform: lowercase;
+}
+
+.post-tools a {
+	padding-right: 10px;
+	cursor: pointer;
+	color: #38C071;
+	text-decoration: none;
+}
+
+.reply-label {
+	padding: 1px 5px;
+	margin: 0;
+	font-size: 12px;
+	line-height: 1.5;
+	color: #333;
+	background-color: #fff;
+	cursor: pointer;
+	border: 1px solid #ccc;
+	white-space: nowrap;
+	-webkit-appearance: button;
+	-moz-appearance: button;
+}
+
+.reply-label:hover {
+	background-color: #E6E6E6;
+}
+
+.hidden {
+	display: none;
+}
+
+.highlight {
+	background-color: rgba(240, 173, 78, 0.75);
+}
+
+.post-content blockquote {
+	font-size: 12px;
+	padding: 10px 20px;
+	margin: 0 0 20px;
+	font-size: 17.5px;
+	border-left: 5px solid #eee;
 }

--- a/public/lib/ghost.js
+++ b/public/lib/ghost.js
@@ -64,6 +64,8 @@
 			for (var post in data.posts) {
 				if (data.posts.hasOwnProperty(post)) {
 					data.posts[post].timestamp = timeAgo(parseInt(data.posts[post].timestamp), 10);
+					data.posts[post].isReply = data.posts[post].hasOwnProperty('toPid') && parseInt(data.posts[post].toPid) !== parseInt(data.tid) - 1;
+					data.posts[post].parentUsername = data.posts[post].hasOwnProperty('parent') ? data.posts[post].parent.username : '';
 					if (data.posts[post]['blog-comments:url']) {
 						delete data.posts[post];
 					}
@@ -143,6 +145,51 @@
 						authenticate('login');
 					}
 				}
+
+				var nodebbCommentsList = nodebbDiv.querySelector('#nodebb-comments-list');
+				var bindOnClick = function(nodeList, handler) {
+					for (var i = nodeList.length - 1; i >= 0; i--) {
+					  nodeList[i].onclick = handler;
+					}
+				};
+
+				bindOnClick(nodebbCommentsList.querySelectorAll('[component="post/parent"]'), function(event) {
+					var goTo = nodebbCommentsList.querySelector('.topic-item[data-pid="' + event.target.getAttribute('data-topid') + '"] .topic-text')
+					goTo.scrollIntoView(true);
+					goTo.classList.add('highlight');
+					setTimeout(function() {
+						goTo.classList.remove('highlight');
+					}, 1000);
+
+				});
+
+				bindOnClick(nodebbCommentsList.querySelectorAll('[component="post/reply"],[component="post/quote"]'), function(event) {
+					var topicItem = event.target;
+					while (topicItem && !topicItem.classList.contains('topic-item')) {
+						topicItem = topicItem.parentElement;
+					}
+
+					if (topicItem) {
+						var elementForm = topicItem.querySelector('form');
+						var visibleForm = nodebbCommentsList.querySelector('li .topic-item form:not(.hidden)');
+						var formInput = elementForm.querySelector('textarea');
+
+						if (visibleForm && visibleForm !== elementForm) {
+							visibleForm.classList.add('hidden');
+						}
+
+						if (/\/quote$/.test(event.target.getAttribute('component'))) {
+							var postBody = topicItem.querySelector('.post-content .post-body');
+							var quote = (postBody.innerText ? postBody.innerText : postBody.textContent).split('\n').map(function(line) { return line ? '> ' + line : line; }).join('\n');
+							formInput.value = '@' + topicItem.getAttribute('data-userslug') + ' said:\n' + quote + formInput.value;
+						} else {
+							formInput.value = '@' + topicItem.getAttribute('data-userslug') + ': ' + formInput.value
+						}
+
+						elementForm.classList.remove('hidden');
+					}
+				});
+
 			} else {
 				if (data.isAdmin) {
 					var markdown = document.getElementById('nbb-markdown').innerHTML

--- a/public/lib/wordpress.js
+++ b/public/lib/wordpress.js
@@ -64,6 +64,8 @@
 			for (var post in data.posts) {
 				if (data.posts.hasOwnProperty(post)) {
 					data.posts[post].timestamp = timeAgo(parseInt(data.posts[post].timestamp), 10);
+					data.posts[post].isReply = data.posts[post].hasOwnProperty('toPid') && parseInt(data.posts[post].toPid) !== parseInt(data.tid) - 1;
+					data.posts[post].parentUsername = data.posts[post].hasOwnProperty('parent') ? data.posts[post].parent.username : '';
 					if (data.posts[post]['blog-comments:url']) {
 						delete data.posts[post];
 					}
@@ -144,6 +146,51 @@
 						authenticate('login');
 					}
 				}
+
+				var nodebbCommentsList = nodebbDiv.querySelector('#nodebb-comments-list');
+				var bindOnClick = function(nodeList, handler) {
+					for (var i = nodeList.length - 1; i >= 0; i--) {
+					  nodeList[i].onclick = handler;
+					}
+				};
+
+				bindOnClick(nodebbCommentsList.querySelectorAll('[component="post/parent"]'), function(event) {
+					var goTo = nodebbCommentsList.querySelector('.topic-item[data-pid="' + event.target.getAttribute('data-topid') + '"] .topic-text')
+					goTo.scrollIntoView(true);
+					goTo.classList.add('highlight');
+					setTimeout(function() {
+						goTo.classList.remove('highlight');
+					}, 1000);
+
+				});
+
+				bindOnClick(nodebbCommentsList.querySelectorAll('[component="post/reply"],[component="post/quote"]'), function(event) {
+					var topicItem = event.target;
+					while (topicItem && !topicItem.classList.contains('topic-item')) {
+						topicItem = topicItem.parentElement;
+					}
+
+					if (topicItem) {
+						var elementForm = topicItem.querySelector('form');
+						var visibleForm = nodebbCommentsList.querySelector('li .topic-item form:not(.hidden)');
+						var formInput = elementForm.querySelector('textarea');
+
+						if (visibleForm && visibleForm !== elementForm) {
+							visibleForm.classList.add('hidden');
+						}
+
+						if (/\/quote$/.test(event.target.getAttribute('component'))) {
+							var postBody = topicItem.querySelector('.post-content .post-body');
+							var quote = (postBody.innerText ? postBody.innerText : postBody.textContent).split('\n').map(function(line) { return line ? '> ' + line : line; }).join('\n');
+							formInput.value = '@' + topicItem.getAttribute('data-userslug') + ' said:\n' + quote + formInput.value;
+						} else {
+							formInput.value = '@' + topicItem.getAttribute('data-userslug') + ': ' + formInput.value
+						}
+
+						elementForm.classList.remove('hidden');
+					}
+				});
+
 			} else {
 				if (data.isAdmin) {
 					var adminXHR = newXHR();

--- a/public/templates/comments/comments.tpl
+++ b/public/templates/comments/comments.tpl
@@ -39,7 +39,7 @@
 						</a>
 					</div>
 					<div class="topic-text">
-						<div class="post-content" itemprop="text"><small><strong>{user.username}</strong> commented {posts.timestamp}</small><br />{posts.content}</div>
+						<div class="post-content" itemprop="text"><small><a href="{relative_path}/user/{user.userslug}" style="color: inherit; text-decoration: none;"><strong>{user.username}</strong></a> commented {posts.timestamp}</small><br />{posts.content}</div>
 					</div>
 				</div>
 			</div>

--- a/public/templates/comments/comments.tpl
+++ b/public/templates/comments/comments.tpl
@@ -27,7 +27,7 @@
 	<ul id="nodebb-comments-list">
 		<!-- BEGIN posts -->
 		<li <!-- IF pagination --> class="nodebb-post-fadein" <!-- ENDIF pagination --> <!-- IF !posts.index --> class="nodebb-post-fadein" <!-- ENDIF !posts.index --> >
-			<div class="topic-item">
+			<div class="topic-item" data-pid="{posts.pid}" data-userslug="{user.userslug}">
 				<div class="topic-body">
 					<div class="topic-profile-pic">
 						<a href="{relative_path}/user/{user.userslug}">
@@ -39,9 +39,17 @@
 						</a>
 					</div>
 					<div class="topic-text">
-						<div class="post-content" itemprop="text"><small><a href="{relative_path}/user/{user.userslug}" style="color: inherit; text-decoration: none;"><strong>{user.username}</strong></a> commented {posts.timestamp}</small><br />{posts.content}</div>
+						<div class="post-content" itemprop="text"><small><span class="post-tools no-select"><a component="post/reply">reply</a><a component="post/quote">quote</a></span><a href="{relative_path}/user/{user.userslug}" style="color: inherit; text-decoration: none;"><strong>{user.username}</strong></a> commented {posts.timestamp} <!-- IF posts.isReply --> <button component="post/parent" class="reply-label no-select" data-topid="{posts.toPid}"><i class="fa fa-reply"></i> @{posts.parentUsername}</button> <!-- ENDIF posts.isReply --> </small><br /><div class="post-body">{posts.content}</div></div>
 					</div>
 				</div>
+				<form action="{relative_path}/comments/reply" method="post" class="sub-reply-input hidden">
+					<textarea id="nodebb-content" class="form-control" name="content" placeholder="Join the conversation" rows="3"></textarea>
+					<button class="btn btn-primary">Reply to {user.username}</button>
+					<input type="hidden" name="_csrf" value="{token}" />
+					<input type="hidden" name="tid" value="{tid}" />
+					<input type="hidden" name="toPid" value="{posts.pid}" />
+					<input type="hidden" name="url" value="{redirect_url}" />
+				</form>
 			</div>
 		</li>
 		<!-- END posts -->


### PR DESCRIPTION
@psychobunny  This implements reply/quote to blog comments. It also adds a label that scrolls to the replied comment (similar to NodeBB's one).
This is meant to be a basic implementation. It would be better to use a scrolling animation rather than `scrollIntoView`, for example.

<img width="405" alt="capture" src="https://cloud.githubusercontent.com/assets/1634092/12262126/1428841c-b969-11e5-8bce-369d4a78b133.PNG">

(The font-size is different in the image due to some local CSS)

I included also a link to the user profile from username because on small resolutions the profile pictures are hidden (those are the links right now).

And by the way, I couldn't figure out how to access to `<!-- IF posts.toPid -->` (it can be a string or undefined) and `{posts.parent.username}`, so I had to create `posts.isReply` and `posts.parentUsername`. If you know a better way I can change it.