### PR TITLE
Prevent 404 Error on after comment posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Activate the plugin in the ACP and reboot NodeBB. Head over to the Blog Comments
 Paste this any where in `yourtheme/post.hbs`, somewhere between `{{#post}}` and `{{/post}}`. All you have to edit is line 3 (`nbb.url`) - put the URL to your NodeBB forum's home page here.
 
 ```html
-<a id="nodebb/comments"></a>
+<a id="nodebb-comments"></a>
 <script type="text/javascript">
 var nbb = {};
 nbb.url = '//your.nodebb.com'; // EDIT THIS

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ nbb.script.src = nbb.url + '/plugins/nodebb-plugin-blog-comments/lib/ghost.js';
 <noscript>Please enable JavaScript to view comments</noscript>
 ```
 
-If you wish, you can move `<a id="nodebb/comments"></a>` to where you want to place the actual comments widget.
+If you wish, you can move `<a id="nodebb-comments"></a>` to where you want to place the actual comments widget.
 
 ### Wordpress Installation
 
@@ -60,7 +60,7 @@ if ( post_password_required() )
 	return;
 ?>
 
-<a id="nodebb/comments"></a>
+<a id="nodebb-comments"></a>
 <script type="text/javascript">
 var nodeBBURL = '//your.nodebb.com',
 	articleID = '<?php echo the_ID(); ?>';

--- a/library.js
+++ b/library.js
@@ -114,10 +114,10 @@
 			content: content
 		}, function(err, postData) {
 			if(err) {
-				return res.redirect(url + '?error=' + err.message + '#nodebb/comments');
+				return res.redirect(url + '?error=' + err.message + '#nodebb-comments');
 			}
 
-			res.redirect(url + '#nodebb/comments');
+			res.redirect(url + '#nodebb-comments');
 		});
 	};
 
@@ -168,7 +168,7 @@
 						}
 						
 						db.setObjectField('blog-comments', commentID, result.postData.tid);
-						res.redirect((req.header('Referer') || '/') + '#nodebb/comments');
+						res.redirect((req.header('Referer') || '/') + '#nodebb-comments');
 					});
 				} else {
 					res.json({error: "Unable to post topic", result: result});

--- a/public/lib/ghost.js
+++ b/public/lib/ghost.js
@@ -12,7 +12,7 @@
 	stylesheet.setAttribute("href", pluginURL + '/css/comments.css');
 
 	document.getElementsByTagName("head")[0].appendChild(stylesheet);
-	document.getElementById('nodebb/comments').insertAdjacentHTML('beforebegin', '<div id="nodebb"></div>');
+	document.getElementById('nodebb-comments').insertAdjacentHTML('beforebegin', '<div id="nodebb"></div>');
 	nodebbDiv = document.getElementById('nodebb');
 
 	function newXHR() {

--- a/public/lib/ghost.js
+++ b/public/lib/ghost.js
@@ -12,7 +12,8 @@
 	stylesheet.setAttribute("href", pluginURL + '/css/comments.css');
 
 	document.getElementsByTagName("head")[0].appendChild(stylesheet);
-	document.getElementById('nodebb-comments').insertAdjacentHTML('beforebegin', '<div id="nodebb"></div>');
+	var nodebbComments = document.getElementById('nodebb-comments') || document.getElementByID('nodebb/comments');
+	nodebbComments.insertAdjacentHTML('beforebegin', '<div id="nodebb"></div>');
 	nodebbDiv = document.getElementById('nodebb');
 
 	function newXHR() {

--- a/public/lib/wordpress.js
+++ b/public/lib/wordpress.js
@@ -12,7 +12,7 @@
 	stylesheet.setAttribute("href", pluginURL + '/css/comments.css');
 
 	document.getElementsByTagName("head")[0].appendChild(stylesheet);
-	document.getElementById('nodebb/comments').insertAdjacentHTML('beforebegin', '<div id="nodebb"></div>');
+	document.getElementById('nodebb-comments').insertAdjacentHTML('beforebegin', '<div id="nodebb"></div>');
 	nodebbDiv = document.getElementById('nodebb');
 
 	function newXHR() {

--- a/public/lib/wordpress.js
+++ b/public/lib/wordpress.js
@@ -12,7 +12,8 @@
 	stylesheet.setAttribute("href", pluginURL + '/css/comments.css');
 
 	document.getElementsByTagName("head")[0].appendChild(stylesheet);
-	document.getElementById('nodebb-comments').insertAdjacentHTML('beforebegin', '<div id="nodebb"></div>');
+	var nodebbComments = document.getElementById('nodebb-comments') || document.getElementByID('nodebb/comments');
+	nodebbComments.insertAdjacentHTML('beforebegin', '<div id="nodebb"></div>');
 	nodebbDiv = document.getElementById('nodebb');
 
 	function newXHR() {


### PR DESCRIPTION
The id tag #nodebb/comments redirects to /nodebb/comments on the article which generates a 404 error. #nodebb-comments should handle properly even after a redirect to /#nodebb-comments