### PR TITLE
make enscaped title and markdown text actually work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ nbb.cid = 1;	// OPTIONAL. Forces a Category ID in NodeBB.
 				//  Omit it to fallback to specified IDs in the admin panel.
 
 (function() {
-nbb.articleID = '{{../post.id}}'; nbb.title = '{{../post.title}}';
+nbb.articleID = '{{../post.id}}';
 nbb.tags = [{{#../post.tags}}"{{name}}",{{/../post.tags}}];
 nbb.script = document.createElement('script'); nbb.script.type = 'text/javascript'; nbb.script.async = true;
 nbb.script.src = nbb.url + '/plugins/nodebb-plugin-blog-comments/lib/ghost.js';
 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(nbb.script);
 })();
 </script>
-<script id="nbb-markdown" type="text/markdown">{{../post.markdown}}</script>
+<span id="nbb-title" style="display:none">{{../post.title}}</span>
+<span id="nbb-markdown" style="display:none">{{../post.markdown}}</span>
 <noscript>Please enable JavaScript to view comments</noscript>
 ```
 
@@ -53,7 +54,7 @@ If you wish, you can move `<a id="nodebb-comments"></a>` to where you want to pl
 
 ### Wordpress Installation
 
-First, install the [Wordpress JSON API](http://wordpress.org/plugins/json-api/) plugin. 
+First, install the [Wordpress JSON API](http://wordpress.org/plugins/json-api/) plugin.
 
 Replace the contents of `/wp-content/themes/YOUR_THEME/comments.php` with the following (back-up the old comments.php, just in case):
 
@@ -87,8 +88,8 @@ Paste this any where that you want load commenting system. All you have to edit 
 	<a id="nodebb-comments"></a>
 	<script type="text/javascript">
 	var nodeBBURL = '//your.nodebb.com',
-	
-	<?php 
+
+	<?php
 		echo "articleID = " .getId().";";
 		$obj = new stdClass();
 		$obj->title_plain = "";
@@ -99,7 +100,7 @@ Paste this any where that you want load commenting system. All you have to edit 
 						// Omit it to fallback to specified IDs in the admin panel.
 		echo "var articleData =" .json_encode($obj).";";
 	?>
-	
+
 	(function() {
 	var nbb = document.createElement('script'); nbb.type = 'text/javascript'; nbb.async = true;
 	nbb.src = nodeBBURL + '/plugins/nodebb-plugin-blog-comments/lib/generalphp.js';
@@ -120,7 +121,7 @@ You must have some getId() function on your website, for example:
             // unique id for each page of your website
             return $id;
         }
-    ?>    
+    ?>
 ```
 
 If you don't have such ID, you can use this function that generates a unique ID from the URL:

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ You may use a comma-separated entry of blogs in the ACP to support publishing fr
 * [NodeBB's Blog](http://blog.nodebb.org) (Ghost).
 * [The Unknown Artist Hour](http://theunknownartisthour.com) (Ghost).
 * [Burn after compiling](http://burnaftercompiling.com) (Wordpress).
-* [Strange Adventures In](https://strangeadventures.in) (Ghost)
+* [Strange Adventures In](https://strangeadventures.in) (Ghost).
+* [V2MM](https://v2mm.tech) (Ghost).
 
 Please submit a PR to add your site here :)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-blog-comments",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "NodeBB Blog Comments (Ghost / WP Commenting Engine)",
   "main": "library.js",
   "scripts": {

--- a/public/lib/ghost.js
+++ b/public/lib/ghost.js
@@ -1,6 +1,6 @@
 (function() {
 	"use strict";
-	
+
 	var articlePath = window.location.protocol + '//' + window.location.host + window.location.pathname;
 
 	var pluginURL = nbb.url + '/plugins/nodebb-plugin-blog-comments',
@@ -33,11 +33,11 @@
 		savedText = contentDiv.value;
 		modal = window.open(nbb.url + "/" + type + "/#blog/authenticate","_blank","toolbar=no, scrollbars=no, resizable=no, width=600, height=675");
 		var timer = setInterval(function() {
-			if(modal.closed) {  
+			if(modal.closed) {
 				clearInterval(timer);
 				pagination = 0;
 				reloadComments();
-			}  
+			}
 		}, 500);
 	}
 
@@ -69,7 +69,7 @@
 					}
 				}
 			}
-			
+
 			if (commentsCounter) {
 				commentsCounter.innerHTML = data.postCount ? (data.postCount - 1) : 0;
 			}
@@ -84,7 +84,7 @@
 
 			if (pagination) {
 				html = normalizePost(parse(data, templates.blocks['posts']));
-				commentsDiv.innerHTML = commentsDiv.innerHTML + html;	
+				commentsDiv.innerHTML = commentsDiv.innerHTML + html;
 			} else {
 				html = parse(data, data.template);
 				nodebbDiv.innerHTML = normalizePost(html);
@@ -100,7 +100,7 @@
 					}
 				}
 			}, 100);
-			
+
 			if (savedText) {
 				contentDiv.value = savedText;
 			}
@@ -112,7 +112,7 @@
 					reloadComments();
 				}
 				if (data.posts.length) {
-					loadMore.style.display = 'inline-block';	
+					loadMore.style.display = 'inline-block';
 				}
 
 				if (pagination * 10 + data.posts.length + 1 >= data.postCount) {
@@ -133,7 +133,7 @@
 						}
 
 						document.getElementById('nodebb-error').innerHTML = error;
-					}					
+					}
 				} else {
 					document.getElementById('nodebb-register').onclick = function() {
 						authenticate('register');
@@ -145,10 +145,10 @@
 				}
 			} else {
 				if (data.isAdmin) {
-					var markdown = unescape(document.getElementById('nbb-markdown').innerHTML);
+					var markdown = document.getElementById('nbb-markdown').innerText;
 					markdown = markdown.split('\n\n').slice(0,2).join('\n\n') + '\n\n**Click [here]('+articlePath+') to see the full blog post**';
 
-					document.getElementById('nodebb-content-title').value = nbb.title;
+					document.getElementById('nodebb-content-title').value = document.getElementById('nbb-title').innerText;
 					document.getElementById('nodebb-content-markdown').value = markdown;
 					document.getElementById('nodebb-content-cid').value = nbb.cid || -1;
 					document.getElementById('nodebb-content-tags').value = JSON.stringify(nbb.tags);
@@ -157,7 +157,7 @@
 		}
 	};
 
-	
+
 
 
 	function reloadComments() {
@@ -191,7 +191,7 @@
 		if (seconds < 10) {
 			return 'just now';
 		}
-		
+
 		var i = 0, format;
 		while (format = time_formats[i++]) {
 			if (seconds < format[0]) {


### PR DESCRIPTION
1. title was escaped, but didn't unescape, so '&' in title would be displayed as '&amp;' on nodebb;

2. use `unescape` function does't really work, not even `decodeURIComponent`. Worse, `unescape` would make encoded unicode URL broken. I think the simplest way is using `element.innerText`.


